### PR TITLE
Fix unicode conversion bug

### DIFF
--- a/japanese-typesetting/src/core/unicode/unicode.cpp
+++ b/japanese-typesetting/src/core/unicode/unicode.cpp
@@ -7,6 +7,7 @@
 #include <unicode/unistr.h>
 #include <unicode/normlzr.h>
 #include <unicode/uchar.h>
+#include <unicode/utf.h>
 #include <algorithm> // std::find用に追加
 
 namespace japanese_typesetting {
@@ -60,8 +61,10 @@ std::u32string UnicodeHandler::utf8ToUtf32(const std::string& utf8String) const 
     std::u32string result;
     result.reserve(ustr.length());
     
-    for (int32_t i = 0; i < ustr.length(); ++i) {
-        result.push_back(static_cast<char32_t>(ustr.char32At(i)));
+    for (int32_t i = 0; i < ustr.length(); ) {
+        UChar32 c = ustr.char32At(i);
+        result.push_back(static_cast<char32_t>(c));
+        i += U16_LENGTH(c);
     }
     
     return result;

--- a/japanese-typesetting/tests/unit/unicode_test.cpp
+++ b/japanese-typesetting/tests/unit/unicode_test.cpp
@@ -1,12 +1,20 @@
-/**
- * @file unicode_test.cpp
- * @brief テスト用の空実装ファイル
- */
-
 #include <gtest/gtest.h>
+#include "japanese_typesetting/core/unicode/unicode.h"
 
-// 基本的なテストケース
-TEST(UnicodeTest, BasicTest) {
-  // 将来的に実装予定
-  EXPECT_TRUE(true);
+using japanese_typesetting::core::unicode::UnicodeHandler;
+
+TEST(UnicodeHandlerTest, Utf8ToUtf32HandlesSupplementaryCharacters) {
+    UnicodeHandler handler;
+    std::string emoji_utf8 = u8"\U0001F600"; // grinning face
+    std::u32string utf32 = handler.utf8ToUtf32(emoji_utf8);
+    ASSERT_EQ(utf32.size(), 1u);
+    EXPECT_EQ(utf32[0], U'\U0001F600');
+}
+
+TEST(UnicodeHandlerTest, Utf32Utf8RoundTrip) {
+    UnicodeHandler handler;
+    std::u32string input = { U'\U0001F600', U'あ', U'\n' };
+    std::string utf8 = handler.utf32ToUtf8(input);
+    std::u32string round = handler.utf8ToUtf32(utf8);
+    EXPECT_EQ(round, input);
 }


### PR DESCRIPTION
## Summary
- fix utf8ToUtf32 to correctly step through UTF‑16 with surrogate pairs
- test UnicodeHandler conversion with supplementary characters

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: The following required packages were not found: harfbuzz)*

------
https://chatgpt.com/codex/tasks/task_e_684264c610d48328b59c5b77daa3913a