### PR TITLE
Adjust run signature

### DIFF
--- a/japanese-typesetting/include/japanese_typesetting/cli/cli.h
+++ b/japanese-typesetting/include/japanese_typesetting/cli/cli.h
@@ -80,7 +80,7 @@ public:
      * @param options コマンドラインオプション
      * @return 成功した場合は0、エラーの場合は非0
      */
-    int run(const CommandLineOptions& options);
+    int run(CommandLineOptions options);
 
 private:
     /**

--- a/japanese-typesetting/src/cli/cli.cpp
+++ b/japanese-typesetting/src/cli/cli.cpp
@@ -192,7 +192,7 @@ void CommandLineInterface::showVersion() const {
     std::cout << "Copyright (C) 2025 Japanese Typesetting Project" << std::endl;
 }
 
-int CommandLineInterface::run(const CommandLineOptions& options) {
+int CommandLineInterface::run(CommandLineOptions options) {
     // ヘルプまたはバージョン情報の表示
     if (options.help) {
         showHelp();


### PR DESCRIPTION
## Summary
- change `CommandLineInterface::run` to pass `CommandLineOptions` by value

## Testing
- `cmake -B build` *(fails: required package harfbuzz not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842672bdc408328801bfc4f7eec3ea4